### PR TITLE
Ensure ObjectDidChangePublisher passes through completion events

### DIFF
--- a/Sources/CombineViewModel/ObjectDidChangePublisher.swift
+++ b/Sources/CombineViewModel/ObjectDidChangePublisher.swift
@@ -38,9 +38,14 @@ private extension ObjectDidChangePublisher {
       }
 
       self.subscription = object.objectWillChange.sink(
-        receiveCompletion: { [weak self] _ in self?.cancel() },
+        receiveCompletion: { [weak self] _ in self?.finish() },
         receiveValue: { _ in source.signal() }
       )
+    }
+
+    func finish() {
+      subscriber?.receive(completion: .finished)
+      cancel()
     }
 
     func serviceDemand() {


### PR DESCRIPTION
The default ObservableObjectPublisher doesn't appear to ever send a completion event, instead being cancelled when its owning object goes out of scope. However, if a custom objectWillChange publisher is provided, make sure we pass through the completion event to preserve its semantics.