### PR TITLE
Remove ViewModelObserver.isReadyForUpdates

### DIFF
--- a/Sources/CombineViewModel/ViewModelObserver.swift
+++ b/Sources/CombineViewModel/ViewModelObserver.swift
@@ -1,23 +1,6 @@
 import Combine
 
 public protocol ViewModelObserver: AnyObject {
-  var isReadyForUpdates: Bool { get }
   var subscriptions: Set<AnyCancellable> { get set }
   func updateView()
 }
-
-extension ViewModelObserver {
-  public var isReadyForUpdates: Bool {
-    true
-  }
-}
-
-#if canImport(UIKit)
-import UIKit
-
-extension UIViewController {
-  @objc open var isReadyForUpdates: Bool {
-    isViewLoaded
-  }
-}
-#endif


### PR DESCRIPTION
Simplifies both the public API and the implementation of `@ViewModel`.