### PR TITLE
ViewModelObserver inherits from BindingOwner

### DIFF
--- a/Example/Sources/CounterViewController.swift
+++ b/Example/Sources/CounterViewController.swift
@@ -8,8 +8,6 @@ final class CounterViewController: UITableViewController, ViewModelObserver {
 
   @ViewModel private var counter: Counter
 
-  var subscriptions: Set<AnyCancellable> = []
-
   required init?(coder: NSCoder) {
     super.init(coder: coder)
 

--- a/Example/Sources/TasksViewController.swift
+++ b/Example/Sources/TasksViewController.swift
@@ -21,8 +21,6 @@ final class TasksViewController: UITableViewController, ViewModelObserver {
     .appendingPathComponent("tasks.json", isDirectory: false)
   @ViewModel private var taskList: TaskList
 
-  var subscriptions: Set<AnyCancellable> = []
-
   required init?(coder: NSCoder) {
     super.init(coder: coder)
 

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     .library(name: "UIKitBindings", targets: ["UIKitBindings"]),
   ],
   targets: [
-    .target(name: "CombineViewModel"),
+    .target(name: "CombineViewModel", dependencies: ["Bindings"]),
     .target(name: "Bindings"),
     .target(name: "UIKitBindings", dependencies: ["Bindings"]),
 

--- a/README.md
+++ b/README.md
@@ -41,17 +41,13 @@ import CombineViewModel
 import UIKit
 
 // (1) Conform your view controller to the ViewModelObserver protocol.
-//
 final class CounterViewController: UIViewController, ViewModelObserver {
   @IBOutlet private var valueLabel: UILabel!
 
   // (2) Declare your view model using the `@ViewModel` property wrapper.
-  //
   @ViewModel private var counter: Counter
-  var subscriptions: Set<AnyCancellable> = []
 
   // (3) Initialize your view model in init().
-  //
   required init?(coder: NSCoder) {
     super.init(coder: coder)
     self.counter = Counter()
@@ -59,7 +55,6 @@ final class CounterViewController: UIViewController, ViewModelObserver {
 
   // (4) The `updateView()` method is automatically called on the main queue
   //     when the view model changes. It is always called after `viewDidLoad()`.
-  //
   func updateView() {
     valueLabel.text = counter.formattedValue
   }

--- a/Sources/CombineViewModel/ViewModel.swift
+++ b/Sources/CombineViewModel/ViewModel.swift
@@ -1,3 +1,4 @@
+import Bindings
 import Combine
 import Dispatch
 #if canImport(UIKit)
@@ -50,9 +51,7 @@ public struct ViewModel<Object: ObservableObject> {
           .eraseToAnyPublisher()
       }
 
-      objectDidChange
-        .sink { [weak observer] in observer?.updateView() }
-        .store(in: &observer.subscriptions)
+      observer.reactive._updateView <~ objectDidChange
     }
   }
 }

--- a/Sources/CombineViewModel/ViewModelObserver.swift
+++ b/Sources/CombineViewModel/ViewModelObserver.swift
@@ -1,6 +1,15 @@
+@_exported import protocol Bindings.BindingOwner
+import Bindings
 import Combine
 
-public protocol ViewModelObserver: AnyObject {
-  var subscriptions: Set<AnyCancellable> { get set }
+public protocol ViewModelObserver: BindingOwner {
   func updateView()
+}
+
+extension Reactive where Base: ViewModelObserver {
+  var _updateView: BindingSink<Base, ()> {
+    BindingSink(owner: base) { observer in
+      observer.updateView()
+    }
+  }
 }

--- a/Tests/CombineViewModelTests/ViewModelTests.swift
+++ b/Tests/CombineViewModelTests/ViewModelTests.swift
@@ -7,7 +7,6 @@ private final class TestViewModel: ObservableObject {
 
 private final class Controller: ViewModelObserver {
   var observations: [Int] = []
-  var subscriptions: Set<AnyCancellable> = []
   @ViewModel var viewModel: TestViewModel
 
   init() {
@@ -37,7 +36,6 @@ import UIKit
 private final class TestViewController: UIViewController, ViewModelObserver {
   @ViewModel var viewModel: TestViewModel
   var observations: [Int] = []
-  var subscriptions: Set<AnyCancellable> = []
 
   init() {
     super.init(nibName: nil, bundle: nil)


### PR DESCRIPTION
Bindings provides the `BindingOwner` protocol, which implicitly extends all conformers with a `Subscriptions` collection. This makes it possible, in a generic context, to scope a given binding to the lifetime of the object that owns the binding.

By inheriting `ViewModelObserver` from `BindingOwner`, all observers gain the benefit of this automatic collection of subscriptions. As a side effect, we can update all our examples to remove the explicit declaration of a `subscriptions` property.