### PR TITLE
Avoid defer for clarity in UnfairAtomic.swap(_:)

### DIFF
--- a/Sources/CombineViewModel/UnfairAtomic.swift
+++ b/Sources/CombineViewModel/UnfairAtomic.swift
@@ -64,11 +64,10 @@ struct UnfairAtomic<Value> {
   func swap(_ newValue: Value) -> Value {
     buffer.withUnsafeMutablePointers { lock, value in
       os_unfair_lock_lock(lock)
-      defer {
-        value.pointee = newValue
-        os_unfair_lock_unlock(lock)
-      }
-      return value.pointee
+      let oldValue = value.move()
+      value.initialize(to: newValue)
+      os_unfair_lock_unlock(lock)
+      return oldValue
     }
   }
 }


### PR DESCRIPTION
Instead of the slightly-fancy defer we were doing to return the old value, be more straightforward and move the old value out of memory before reinitialising it with the newValue.