### PR TITLE
Work around segfault compiling ObjCRuntime.swift in Release config

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -42,8 +42,18 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Build
+      - name: Build Bindings
         run: |
           xcodebuild -configuration Release \
-            -scheme CombineViewModel-Package \
+            -scheme Bindings \
+            -destination 'platform=iOS Simulator,name=iPhone 11'
+      - name: Build UIKitBindings
+        run: |
+          xcodebuild -configuration Release \
+            -scheme UIKitBindings \
+            -destination 'platform=iOS Simulator,name=iPhone 11'
+      - name: Build CombineViewModel
+        run: |
+          xcodebuild -configuration Release \
+            -scheme CombineViewModel \
             -destination 'platform=iOS Simulator,name=iPhone 11'

--- a/Sources/CombineViewModel/ObjCRuntime.swift
+++ b/Sources/CombineViewModel/ObjCRuntime.swift
@@ -26,9 +26,9 @@ extension UIViewController {
     guard !combinevm_isHooked(type(of: self)) else { return }
 
     var originalIMP: IMP!
-    let `class`: AnyClass
+    let `class`: Any
     let method: Method
-    let selector = #selector(self.viewDidLoad)
+    let selector = #selector(viewDidLoad)
 
     (method, `class`) = object_getInstanceMethod(self, name: selector)!
 


### PR DESCRIPTION
When the local variable `class` is declared as type `AnyClass`, the compiler segfaults on line 43 when it is coerced to type `Any`. Avoiding `AnyClass` altogether works around the segfault.