### PR TITLE
Avoid posting UIViewController.viewDidLoadNotification recursively

### DIFF
--- a/Tests/CombineViewModelTests/HookedViewDidLoadTests.swift
+++ b/Tests/CombineViewModelTests/HookedViewDidLoadTests.swift
@@ -40,5 +40,30 @@ final class HookedViewDidLoadTests: XCTestCase {
 
     XCTAssertEqual(controller.viewDidLoadSelector, #selector(UIViewController.viewDidLoad))
   }
+
+  func testRecursiveViewDidLoad() {
+    class ViewModelObserver: UIViewController {
+      override func viewDidLoad() {
+        super.viewDidLoad()
+      }
+    }
+
+    class Unrelated: UIViewController {}
+
+    let observer = ViewModelObserver()
+    observer.hookViewDidLoad()
+    Unrelated().hookViewDidLoad()
+
+    var notificationCount = 0
+
+    let token = NotificationCenter.default.addObserver(forName: UIViewController.viewDidLoadNotification, object: observer, queue: nil) { _ in
+      notificationCount += 1
+    }
+    defer { NotificationCenter.default.removeObserver(token) }
+
+    _ = observer.view
+
+    XCTAssertEqual(notificationCount, 1, "Expected recursively-hooked viewDidLoad() to fire only a single notification.")
+  }
 }
 #endif


### PR DESCRIPTION
When a `UIViewController` that does not override `viewDidLoad()` registers a `@ViewModel` property, the `UIViewController` implementation of `viewDidLoad()` is swizzled. When an unrelated class that does override `viewDidLoad()` registers a `@ViewModel`, it now has multiple swizzled implementations in its class hierarchy. The result is `UIViewController.viewDidLoadNotification` being posted multiple times for the same invocation of `viewDidLoad()` on a `UIViewController` subclass, once for each implementation of `viewDidLoad()` in the call stack.

Use an associated object to keep track of whether a `viewDidLoad()` implementation earlier in the stack is already planning to post the notification, so that recursive calls can check this property and skip posting duplicate notifications.

This maintains the desired property that `UIViewController.viewDidLoadNotification` is posted only once, after the most-derived `viewDidLoad()` implementation returns. It should guarantee that a given `ViewModelObserver` class has loaded all the views it knows about before accessing them in `updateView()`.